### PR TITLE
Update StepTwo component's title in GeneratorForm

### DIFF
--- a/src/components/Form/GeneratorForm/StepTwo/index.tsx
+++ b/src/components/Form/GeneratorForm/StepTwo/index.tsx
@@ -188,7 +188,7 @@ const StepTwo = ({ previousStep }: StepTwoProps) => {
               lists={Object.values(restInstructions).map((list, idx) => ({
                 list,
                 title:
-                  ['Ciasto', 'Farsz', 'Formowanie i przygotowanie pierogów']?.[
+                  ['Ciasto:', 'Farsz', 'Formowanie i przygotowanie pierogów:']?.[
                     idx
                   ] ?? '',
               }))}


### PR DESCRIPTION
This commit updates the title of the StepTwo component in the GeneratorForm. The previous titles were 'Ciasto', 'Farsz', and 'Formowanie i przygotowanie pierogów', and they have been changed to 'Ciasto:', 'Farsz', and 'Formowanie i przygotowanie pierogów:'.